### PR TITLE
Fixing AWS session generation error with when logic + change for regex matching

### DIFF
--- a/inc/_setup.yml
+++ b/inc/_setup.yml
@@ -84,10 +84,11 @@
 
 - set_fact:
     expected_local_tfstate: "{{ target_layer_dir }}/{{ deploy_env }}.{{ deploy_region }}.tfstate"
+# format tfvars file as cmd line parameters
     var_files_options: >-
       {{
         generated_tfvars|default([])
-        |map('regex_replace', '(.*)', '-var-file=\1')
+        |map('regex_replace', '^(.*)$', '-var-file=\1')
         |list
       }}
 

--- a/taco.yml
+++ b/taco.yml
@@ -5,19 +5,29 @@
 
   tasks:
     - block:
-        - name: try to assume a role before starting terraform work
-          sts_assume_role:
-            role_arn: "{{ initial_role }}"
-            role_session_name: "{{ initial_role.split('/')[-1] }}"
-            region: "{{ deploy_region }}"
-          register: initial_assume_role
+        - block:
+          - name: try to assume a role before starting terraform work
+            sts_assume_role:
+              role_arn: "{{ initial_role }}"
+              role_session_name: "{{ initial_role.split('/')[-1] }}"
+              region: "{{ deploy_region }}"
+            register: initial_assume_role
 
-        - name: role assumed, picking vars to feed terraform env vars
+          - name: role assumed, picking vars to feed terraform env vars
+            set_fact:
+              aws_credentials:
+                access_key: "{{ initial_assume_role.sts_creds.access_key }}"
+                secret_key: "{{ initial_assume_role.sts_creds.secret_key }}"
+                session_token: "{{ initial_assume_role.sts_creds.session_token }}"
+          when: initial_role is defined
+
+        - name: fallback on using AWS env vars
           set_fact:
             aws_credentials:
-              access_key: "{{ initial_assume_role.sts_creds.access_key }}"
-              secret_key: "{{ initial_assume_role.sts_creds.secret_key }}"
-              session_token: "{{ initial_assume_role.sts_creds.session_token }}"
+              access_key: "{{ lookup('env', 'AWS_ACCESS_KEY_ID') }}"
+              secret_key: "{{ lookup('env', 'AWS_SECRET_ACCESS_KEY') }}"
+              session_token: "{{ lookup('env', 'AWS_SESSION_TOKEN') }}"
+          when: initial_role is undefined
       rescue:
         - name: fallback on using AWS env vars
           set_fact:


### PR DESCRIPTION
- Fixing AWS session creation error from block/rescue logic with when condition, fallback to credentials is done on condition or error, no more task error in result even if it works
- Adding regex matching expression whole string matching, had cases where it matched a second time adding a -var-file= suffix to var files parameters