### PR TITLE
update apply and destroy  + add terraform action

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,12 +29,19 @@ These sub-directories `terraform/*` will be our *layers* directories.
 ## Usage
 
 Run `ansible-playbook ${TACO_HOME}/taco.yml` from the root of a compliant Terraform project.
-  * You will have to supply 4 variables to the ansible run :
-    * `tflayer`: the name of the Terraform layer you want to target. Can be any subdirectory of the `terraform/` directory
-    * `deploy_env`: a label that should be used to differenciate you several tfstates
-    * `deploy_region`: the region you intend to apply your Terraform layer.
-    * `tfaction`: the desired Terraform workflow phase you want. Can be one of `[ init | plan | apply | destroy ]`
-
+  * You will have to supply some variables to the ansible run :
+    * `tflayer`        : the name of the Terraform layer you want to target. Can be any subdirectory of the `terraform/` directory
+    * `deploy_env`     : a label that should be used to differenciate you several tfstates
+    * `deploy_region`  : the region you intend to apply your Terraform layer.
+    * `tfaction`       : the desired Terraform workflow phase you want. Can be one of `[ init | plan | apply | refresh | import | output | destroy ]`  
+* For some Terraform workflow phases, you will need to supply additionally variables to the ansible run
+    * Mandatory variables when running `import` terraform workflow phase :
+        * `tf_addr` : specify the address to import the resource to
+        * `tf_id`   : specify the resource-specific ID to identify that resource being imported
+    * Optional variables when running `output` terraform workflow phase :
+        * `tf_name`        : specify the name of the resource to output
+        * `tf_output_file` : specify the name of the output file where the `output` result command will be redirect (file will be available on taco layer target directory)
+         
 ## Smartly managing variables
 
 The main feature of TACO is to deport variables in YAML files and rely on Ansible variable and templating

--- a/host_vars/localhost.yml
+++ b/host_vars/localhost.yml
@@ -39,6 +39,11 @@ tf_apply_cmd: >-
   {{ tf_cmd_std_redir_suffix }}
 
 
+tf_plan_destroy_cmd_debug_msg: "{{ tf_cmd_chdir_prefix }} {{ tf_plan_destroy_cmd }}"
+tf_plan_destroy_cmd: >-
+  terraform plan -destroy {{ tf_common_options }}
+
+
 tf_destroy_cmd_debug_msg: "{{ tf_cmd_chdir_prefix }} {{ tf_destroy_cmd }}"
 tf_destroy_cmd: >-
   terraform destroy -force {{ tf_common_options }}

--- a/host_vars/localhost.yml
+++ b/host_vars/localhost.yml
@@ -53,3 +53,9 @@ tf_destroy_cmd: >-
 tf_refresh_cmd_debug_msg: "{{ tf_cmd_chdir_prefix }} {{ tf_refresh_cmd }}"
 tf_refresh_cmd: >-
   terraform refresh {{ tf_common_options }}
+
+
+tf_import_cmd_debug_msg: "{{ tf_cmd_chdir_prefix }} {{ tf_import_cmd }}"
+tf_import_cmd: >-
+  terraform import {{ tf_addr }} {{ tf_id }}
+  {{ tf_cmd_std_redir_suffix }}

--- a/host_vars/localhost.yml
+++ b/host_vars/localhost.yml
@@ -48,3 +48,8 @@ tf_destroy_cmd_debug_msg: "{{ tf_cmd_chdir_prefix }} {{ tf_destroy_cmd }}"
 tf_destroy_cmd: >-
   terraform destroy -force {{ tf_common_options }}
   {{ tf_cmd_std_redir_suffix }}
+
+
+tf_refresh_cmd_debug_msg: "{{ tf_cmd_chdir_prefix }} {{ tf_refresh_cmd }}"
+tf_refresh_cmd: >-
+  terraform refresh {{ tf_common_options }}

--- a/host_vars/localhost.yml
+++ b/host_vars/localhost.yml
@@ -59,3 +59,12 @@ tf_import_cmd_debug_msg: "{{ tf_cmd_chdir_prefix }} {{ tf_import_cmd }}"
 tf_import_cmd: >-
   terraform import {{ tf_addr }} {{ tf_id }}
   {{ tf_cmd_std_redir_suffix }}
+
+
+tf_output_options: >-
+  {% if tf_name is defined %}{{ tf_name }} {% endif -%}
+  {% if tf_output_file is defined %}2>&1 > {{ target_layer_dir }}/{{ tf_output_file }}{% endif -%}
+
+tf_output_cmd_debug_msg: "{{ tf_cmd_chdir_prefix }} {{ tf_output_cmd }}"
+tf_output_cmd: >-
+  terraform output {{ tf_output_options }}

--- a/inc/_setup.yml
+++ b/inc/_setup.yml
@@ -3,7 +3,7 @@
   assert:
     that:
       - vars[item] is defined
-      - vars[item] != ''
+      - vars[item] | length > 0
     msg: "Mandatory variable '{{ item }}' missing"
   with_items:
     - tflayer

--- a/inc/_tf_apply.yml
+++ b/inc/_tf_apply.yml
@@ -23,8 +23,12 @@
     verbosity: 1
 
 - name: Terraform apply on {{ tflayer }}
-  shell: >-
+  shell: >
     {{ tf_apply_cmd }}
   args:
     chdir: "{{ src_layer_dir }}"
   when: not (dry_run|bool)
+
+- name: Show output on {{ tflayer }}
+  debug:
+    msg: "{{ lookup('file', '{{ target_layer_dir }}/{{ deploy_env }}.{{ deploy_region }}.live.out') }}"

--- a/inc/_tf_apply.yml
+++ b/inc/_tf_apply.yml
@@ -32,3 +32,4 @@
 - name: Show output on {{ tflayer }}
   debug:
     msg: "{{ lookup('file', '{{ target_layer_dir }}/{{ deploy_env }}.{{ deploy_region }}.live.out') }}"
+  when: not (dry_run|bool)

--- a/inc/_tf_destroy.yml
+++ b/inc/_tf_destroy.yml
@@ -1,5 +1,5 @@
 ---
-- include_tasks: "{{ playbook_dir }}/inc/_tf_init.yml"
+- include_tasks: "{{ playbook_dir }}/inc/_tf_plan_destroy.yml"
 
 - pause:
     prompt: "Type 'destroy' if you want this to be done."

--- a/inc/_tf_import.yml
+++ b/inc/_tf_import.yml
@@ -1,0 +1,29 @@
+---
+- name: Check for mandatory tf_addr var
+  assert:
+    that:
+      - tf_addr is defined
+      - tf_addr | length > 0
+    msg: "Mandatory variable 'tf_addr' missing - tf_addr specify the address to import the ressource to"
+
+- name: Check for mandatory tf_id var
+  assert:
+    that:
+      - tf_id is defined
+      - tf_id | length > 0
+    msg: "Mandatory variable 'tf_id' missing - tf_id specify the resource-specific ID to identify that resource being imported"
+
+- include_tasks: "{{ playbook_dir }}/inc/_tf_init.yml"
+
+- name: Terraform import command
+  debug:
+    msg: "{{ tf_import_cmd_debug_msg }}"
+    verbosity: 1
+
+
+- name: Terraform import on {{ tflayer }}
+  command: "{{ tf_import_cmd }}"
+  args:
+    chdir: "{{ src_layer_dir }}"
+  register: tf_import
+

--- a/inc/_tf_import.yml
+++ b/inc/_tf_import.yml
@@ -4,7 +4,7 @@
     that:
       - tf_addr is defined
       - tf_addr | length > 0
-    msg: "Mandatory variable 'tf_addr' missing - tf_addr specify the address to import the ressource to"
+    msg: "Mandatory variable 'tf_addr' missing - tf_addr specify the address to import the resource to"
 
 - name: Check for mandatory tf_id var
   assert:

--- a/inc/_tf_output.yml
+++ b/inc/_tf_output.yml
@@ -1,0 +1,17 @@
+---
+- name: Terraform output command
+  debug:
+    msg: "{{ tf_output_cmd_debug_msg }}"
+    verbosity: 1
+
+- name: Terraform output on {{ tflayer }}
+  command: "{{ tf_output_cmd }}"
+  args:
+    chdir: "{{ src_layer_dir }}"
+  register: tf_output
+  when: not dry_run
+
+- name: Show output on {{ tflayer }}
+  debug: 
+    msg: "{{ tf_output.stdout }}"
+  when: not dry_run

--- a/inc/_tf_plan_destroy.yml
+++ b/inc/_tf_plan_destroy.yml
@@ -1,0 +1,32 @@
+---
+- include_tasks: "{{ playbook_dir }}/inc/_tf_init.yml"
+
+- name: Terraform plan destroy command
+  debug:
+    msg: "{{ tf_plan_destroy_cmd_debug_msg }}"
+    verbosity: 1
+
+- name: Terraform plan destroy on {{ tflayer }}
+  command: "{{ tf_plan_destroy_cmd }}"
+  args:
+    chdir: "{{ src_layer_dir }}"
+  register: tf_plan_destroy
+
+- name: Display destroy plan result and prompt validation
+  pause:
+    prompt: |
+      {{ tf_plan_destroy.stdout }}
+      #
+      ##
+      ###
+      #### READ CAREFULLY !!!
+      Press 'ENTER' to continue
+  register: tf_plan_destroy_prompt
+  when:
+    - not auto_apply
+    - not dry_run
+
+- name: Display destroy plan result
+  debug:
+    msg: "{{ tf_plan_destroy.stdout }}"
+  when: auto_apply

--- a/inc/_tf_refresh.yml
+++ b/inc/_tf_refresh.yml
@@ -1,0 +1,16 @@
+---
+- name: Terraform refresh command
+  debug:
+    msg: "{{ tf_refresh_cmd_debug_msg }}"
+    verbosity: 1
+
+- name: Terraform refresh on {{ tflayer }}
+  command: "{{ tf_refresh_cmd }}"
+  args:
+    chdir: "{{ src_layer_dir }}"
+  register: tf_output
+  when: not dry_run
+
+- name: Show refresh on {{ tflayer }}
+  debug: 
+    msg: "{{ tf_output.stdout }}"

--- a/taco.yml
+++ b/taco.yml
@@ -18,7 +18,7 @@
         - remote_stack_url is defined
         - remote_stack_version is defined
 
-     - import_tasks: "{{ playbook_dir }}/inc/_setup.yml"
+    - import_tasks: "{{ playbook_dir }}/inc/_setup.yml"
 
   tasks:
     - import_tasks: "{{ playbook_dir }}/inc/_tf_{{ tfaction }}.yml"

--- a/taco.yml
+++ b/taco.yml
@@ -18,7 +18,7 @@
         - remote_stack_url is defined
         - remote_stack_version is defined
 
-    - import_tasks: "{{ playbook_dir }}/inc/_setup.yml"
+     - import_tasks: "{{ playbook_dir }}/inc/_setup.yml"
 
   tasks:
     - import_tasks: "{{ playbook_dir }}/inc/_tf_{{ tfaction }}.yml"

--- a/taco.yml
+++ b/taco.yml
@@ -18,7 +18,7 @@
         - remote_stack_url is defined
         - remote_stack_version is defined
 
-    - import_tasks: "{{ playbook_dir }}/inc/_setup.yml"
+    #- import_tasks: "{{ playbook_dir }}/inc/_setup.yml"
 
   tasks:
     - import_tasks: "{{ playbook_dir }}/inc/_tf_{{ tfaction }}.yml"

--- a/taco.yml
+++ b/taco.yml
@@ -18,7 +18,7 @@
         - remote_stack_url is defined
         - remote_stack_version is defined
 
-    #- import_tasks: "{{ playbook_dir }}/inc/_setup.yml"
+    - import_tasks: "{{ playbook_dir }}/inc/_setup.yml"
 
   tasks:
     - import_tasks: "{{ playbook_dir }}/inc/_tf_{{ tfaction }}.yml"


### PR DESCRIPTION
Update existing action : 
- apply command 
  -> view output result in Ansible execution
- destroy command 
 -> add a new step task to exec a `terraform plan -destroy` to show what destroy will do

Add missing terraform worflow phases to TACO : 
- import (2 new mandatory variables)
- output (2 optional variables)
- refresh