### PR TITLE
Features/tf state

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,10 @@ Run `ansible-playbook ${TACO_HOME}/taco.yml` from the root of a compliant Terraf
         * `tf_addr` : specify the address to import the resource to
         * `tf_id`   : specify the resource-specific ID to identify that resource being imported
     * Mandatory variables when running `state` terraform workflow phase :
-        * `tf_state_action` : specify the state action wanted (e.g. rm, pull, show...)
+        * `tf_state_action` : specify the state action wanted. Supported actions : `list`, `show`, `pull`, `rm`.
+        * Semi-mandatory `tf_addr` (can be left to an empty string) : specify the address targeted by the state action  
+          * e.g. for a `terraform state rm ADRESS`, you need to give the targeted resource adress : `tf_addr="aws_iam_user.targeted_user"`
+          * e.g. for a `terraform state [list,pull]`, you need to set `tf_addr=""`.
      * Optional variables when running `output` terraform workflow phase :
         * `tf_name`        : specify the name of the resource to output
         * `tf_output_file` : specify the name of the output file where the `output` result command will be redirect (file will be available on taco layer target directory)

--- a/README.md
+++ b/README.md
@@ -40,12 +40,10 @@ Run `ansible-playbook ${TACO_HOME}/taco.yml` from the root of a compliant Terraf
         * `tf_id`   : specify the resource-specific ID to identify that resource being imported
     * Mandatory variables when running `state` terraform workflow phase :
         * `tf_state_action` : specify the state action wanted (e.g. rm, pull, show...)
-    * Optional variables when running `state` terraform workflow phase :
-        * `tf_addr` : specify the address targeted by the state change (.e.g. when doing a `terraform state rm`, you need to give the target resource adress)
      * Optional variables when running `output` terraform workflow phase :
         * `tf_name`        : specify the name of the resource to output
         * `tf_output_file` : specify the name of the output file where the `output` result command will be redirect (file will be available on taco layer target directory)
-         
+
 ## Smartly managing variables
 
 The main feature of TACO is to deport variables in YAML files and rely on Ansible variable and templating

--- a/README.md
+++ b/README.md
@@ -33,12 +33,16 @@ Run `ansible-playbook ${TACO_HOME}/taco.yml` from the root of a compliant Terraf
     * `tflayer`        : the name of the Terraform layer you want to target. Can be any subdirectory of the `terraform/` directory
     * `deploy_env`     : a label that should be used to differenciate you several tfstates
     * `deploy_region`  : the region you intend to apply your Terraform layer.
-    * `tfaction`       : the desired Terraform workflow phase you want. Can be one of `[ init | plan | apply | refresh | import | output | destroy ]`  
+    * `tfaction`       : the desired Terraform workflow phase you want. Can be one of `[ init | plan | apply | refresh | import | state | output | destroy ]`  
 * For some Terraform workflow phases, you will need to supply additionally variables to the ansible run
     * Mandatory variables when running `import` terraform workflow phase :
         * `tf_addr` : specify the address to import the resource to
         * `tf_id`   : specify the resource-specific ID to identify that resource being imported
-    * Optional variables when running `output` terraform workflow phase :
+    * Mandatory variables when running `state` terraform workflow phase :
+        * `tf_state_action` : specify the state action wanted (e.g. rm, pull, show...)
+    * Optional variables when running `state` terraform workflow phase :
+        * `tf_addr` : specify the address targeted by the state change (.e.g. when doing a `terraform state rm`, you need to give the target resource adress)
+     * Optional variables when running `output` terraform workflow phase :
         * `tf_name`        : specify the name of the resource to output
         * `tf_output_file` : specify the name of the output file where the `output` result command will be redirect (file will be available on taco layer target directory)
          

--- a/host_vars/localhost.yml
+++ b/host_vars/localhost.yml
@@ -61,6 +61,11 @@ tf_import_cmd: >-
   {{ tf_cmd_std_redir_suffix }}
 
 
+tf_state_cmd_debug_msg: "{{ tf_cmd_chdir_prefix }} {{ tf_state_cmd }}"
+tf_state_cmd: >-
+  terraform state {{ tf_state_action }} {{ tf_addr }}
+
+
 tf_output_options: >-
   {% if tf_name is defined %}{{ tf_name }} {% endif -%}
   {% if tf_output_file is defined %}2>&1 > {{ target_layer_dir }}/{{ tf_output_file }}{% endif -%}

--- a/host_vars/localhost.yml
+++ b/host_vars/localhost.yml
@@ -63,8 +63,7 @@ tf_import_cmd: >-
 
 tf_state_cmd_debug_msg: "{{ tf_cmd_chdir_prefix }} {{ tf_state_cmd }}"
 tf_state_cmd: >-
-  terraform state {{ tf_state_action }} {{ tf_addr }}
-
+  terraform state {{ tf_state_action }}
 
 tf_output_options: >-
   {% if tf_name is defined %}{{ tf_name }} {% endif -%}

--- a/inc/_tf_state.yml
+++ b/inc/_tf_state.yml
@@ -8,6 +8,14 @@
 
 - include_tasks: "{{ playbook_dir }}/inc/_tf_init.yml"
 
+- name: Check for mandatory tf_addr var
+  assert:
+    that:
+      - tf_addr is defined
+    msg: "Semi-mandatory (can be passed as an empty string) variable 'tf_addr' is missing - tf_addr specify the state action wanted"
+
+- include_tasks: "{{ playbook_dir }}/inc/_tf_init.yml"
+
 - name: Terraform state command
   debug:
     msg: "{{ tf_state_cmd_debug_msg }}"

--- a/inc/_tf_state.yml
+++ b/inc/_tf_state.yml
@@ -1,0 +1,21 @@
+---
+- name: Check for mandatory tf_state_action var
+  assert:
+    that:
+      - tf_state_action is defined
+      - tf_state_action | length > 0
+    msg: "Mandatory variable 'tf_state_action' missing - tf_state_action specify the state action wanted"
+
+- include_tasks: "{{ playbook_dir }}/inc/_tf_init.yml"
+
+- name: Terraform state command
+  debug:
+    msg: "{{ tf_state_cmd_debug_msg }}"
+    verbosity: 1
+
+
+- name: Terraform state on {{ tflayer }}
+  command: "{{ tf_state_cmd }}"
+  args:
+    chdir: "{{ src_layer_dir }}"
+  register: tf_state


### PR DESCRIPTION
Adding the ability to use terraform's state features.

e.g. : for `terraform state rm [options] ADDRESS` :
```
ansible-playbook ${TACO_HOME}/taco.yml -e tflayer=${YOUR_LAYER} -e deploy_env=${YOUR_ENV} -e deploy_region=${YOUR_REGION} -e tfaction=state -e tf_state_action=rm -e tf_addr=${THE_RESOURCE_ADRESS}
```